### PR TITLE
Retrofit & network module response handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.10"

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -12,7 +12,6 @@ android {
     defaultConfig {
         minSdk = libs.versions.minSdkVersion.get().toInt()
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
 
@@ -35,6 +34,9 @@ android {
 }
 
 dependencies {
+    testImplementation(libs.junit)
+    testImplementation (libs.mockito.kotlin)
+
     // retrofit
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson.converter)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -13,6 +13,8 @@ android {
         minSdk = libs.versions.minSdkVersion.get().toInt()
 
         consumerProguardFiles("consumer-rules.pro")
+
+        buildConfigField ("String", "BASE_URL", "\"https://run.mocky.io/\"")
     }
 
     buildTypes {
@@ -30,6 +32,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -33,5 +35,12 @@ android {
 }
 
 dependencies {
+    // retrofit
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.gson.converter)
+    implementation(libs.okhttp3.logging.interceptor)
 
+    // hilt
+    implementation(libs.dagger.hilt)
+    ksp(libs.dagger.hilt.compiler)
 }

--- a/core/network/src/main/AndroidManifest.xml
+++ b/core/network/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
 </manifest>

--- a/core/network/src/main/java/com/shahin/core/network/NetworkResponseWrapper.kt
+++ b/core/network/src/main/java/com/shahin/core/network/NetworkResponseWrapper.kt
@@ -1,0 +1,53 @@
+package com.shahin.core.network
+
+import com.shahin.core.network.model.ErrorReason
+import com.shahin.core.network.model.NetworkResponse
+import retrofit2.Response
+import java.io.IOException
+
+/**
+ * A wrapper handler to standardize handling of network responses.
+ *
+ *
+ * Returns:
+ * [NetworkResponse.Success] wrapping the response body when invoked [Response] (retrofitResponse)
+ * is successful
+ *
+ * Returns:
+ * [NetworkResponse.ServerError] wrapping [ErrorReason] containing error code and response message when
+ * invoked [Response] (retrofitResponse) responds with remote side failure
+ *
+ * Returns:
+ *  * [NetworkResponse.NetworkError] containing no data when invoked [Response] (retrofitResponse) is
+ *  * failed due to client side failure of no network connection or unknown host
+ *
+ * Returns:
+ * [NetworkResponse.ClientError] containing [Throwable] when invoked [Response] (retrofitResponse) is
+ * failed due to client side failure of any reason other than [NetworkResponse.NetworkError]
+ * Failures such as parsing and serialization exceptions, etc..
+ */
+open class NetworkResponseWrapper {
+
+    inline fun <T: Any> networkResponseOf(retrofitResponse: () -> Response<T>) : NetworkResponse<T> {
+        try {
+            val response = retrofitResponse()
+            return if (response.isSuccessful) {
+                NetworkResponse.Success(response.body())
+            } else {
+                NetworkResponse.ServerError(
+                    ErrorReason(
+                        errorCode = response.code(),
+                        errorMessage = response.message()
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return NetworkResponse.NetworkError
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return NetworkResponse.ClientError(e)
+        }
+    }
+
+}

--- a/core/network/src/main/java/com/shahin/core/network/model/ErrorReason.kt
+++ b/core/network/src/main/java/com/shahin/core/network/model/ErrorReason.kt
@@ -1,0 +1,11 @@
+package com.shahin.core.network.model
+
+/**
+ * representing network error response
+ *
+ * This is used because our http endpoint doesn't have a representable error body in case of failure
+ */
+data class ErrorReason(
+    val errorCode: Int,
+    val errorMessage: String
+)

--- a/core/network/src/main/java/com/shahin/core/network/model/NetworkResponse.kt
+++ b/core/network/src/main/java/com/shahin/core/network/model/NetworkResponse.kt
@@ -1,0 +1,21 @@
+package com.shahin.core.network.model
+
+/**
+ * Remote response wrapper
+ *
+ * [Success] represents a successful network response wrapping data of type [T]
+ * [ServerError] represents an remote server error response with a specified error reason in [ErrorReason]
+ * [ClientError] represents any failure except network connection occurring from the client side, such as parsing failure, wrapping a [Throwable]
+ * [NetworkResponse] represents a client side network error such no internet connection or unknown host failures with no specific type information [Nothing]
+ * */
+sealed class NetworkResponse<out T> {
+
+    data class Success<T>(val data: T? = null) : NetworkResponse<T>()
+
+    data class ServerError<T>(val error: ErrorReason) : NetworkResponse<T>()
+
+    data class ClientError<T>(val throwable: Throwable) : NetworkResponse<T>()
+
+    data object NetworkError : NetworkResponse<Nothing>()
+
+}

--- a/core/network/src/test/java/com/shahin/core/network/NetworkResponseWrapperTest.kt
+++ b/core/network/src/test/java/com/shahin/core/network/NetworkResponseWrapperTest.kt
@@ -1,0 +1,83 @@
+package com.shahin.core.network
+
+import com.shahin.core.network.model.ErrorReason
+import com.shahin.core.network.model.NetworkResponse
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+import retrofit2.Response
+import java.io.IOException
+
+class NetworkResponseWrapperTest {
+
+    private val networkResponseWrapper = NetworkResponseWrapper()
+
+    @Test
+    fun `networkResponseOf returns Success for successful response`() {
+        val mockResponse = Response.success("Success Data")
+        val result = networkResponseWrapper.networkResponseOf { mockResponse }
+        assertEquals(NetworkResponse.Success("Success Data"), result)
+    }
+
+    /**
+     * It really doesn't matter what's inside our response body
+     * [networkResponseOf] should work the same as we are passing whatever as server response
+     */
+    data class MockResponseBody(
+        val id: Int,
+        val bookDetails: String
+    )
+
+    /**
+     * Asserting successful response handling functionality
+     */
+    @Test
+    fun `mockito networkResponseOf returns Success for successful response`() {
+        val mockResponse = Mockito.mock(Response::class.java)
+        Mockito.`when`(mockResponse.isSuccessful).thenReturn(true)
+        Mockito.`when`(mockResponse.code()).thenReturn(200)
+
+        val responseBody = mutableListOf<MockResponseBody>()
+        repeat(10) {
+            responseBody.add(
+                MockResponseBody(
+                    id = it,
+                    bookDetails = "details $it"
+                )
+            )
+        }
+
+        Mockito.`when`(mockResponse.body()).thenReturn(responseBody)
+
+        val result = networkResponseWrapper.networkResponseOf { mockResponse }
+
+        assertEquals(NetworkResponse.Success<List<MockResponseBody>>(responseBody), result)
+    }
+
+    @Test
+    fun `networkResponseOf returns ServerError for unsuccessful response`() {
+        val mockResponse = Mockito.mock(Response::class.java)
+        Mockito.`when`(mockResponse.isSuccessful).thenReturn(false)
+        Mockito.`when`(mockResponse.code()).thenReturn(500)
+        Mockito.`when`(mockResponse.message()).thenReturn("Server error")
+
+        val result = networkResponseWrapper.networkResponseOf { mockResponse }
+
+        assertEquals(NetworkResponse.ServerError<Any>(ErrorReason(500, "Server error")), result)
+    }
+
+    @Test
+    fun `networkResponseOf returns NetworkError for IOException`() {
+        val exception = IOException("IO Exception")
+        val result = networkResponseWrapper.networkResponseOf<Any> { throw exception }
+        assertEquals(NetworkResponse.NetworkError, result)
+    }
+
+    @Test
+    fun `networkResponseOf returns ClientError for other exceptions`() {
+        val clientSideException = Exception("Generic Exception")
+        val result = networkResponseWrapper.networkResponseOf<Any> { throw clientSideException }
+        assertEquals(NetworkResponse.ClientError<Any>(clientSideException), result)
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ ksp = "2.0.0-1.0.21"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 retrofit = "2.11.0"
-kotlinxSerializationJson = "1.6.3"
 okhttp3 = "4.12.0"
+mockitoKotlin = "5.3.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +34,9 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+
+# mockito
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 
 # hilt
 dagger-hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,9 @@ composeBom = "2024.06.00"
 ksp = "2.0.0-1.0.21"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
+retrofit = "2.11.0"
+kotlinxSerializationJson = "1.6.3"
+okhttp3 = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,6 +39,12 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 dagger-hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 dagger-hilt-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+#retrofit
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-gson-converter = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### Added retrofit dependency to network module

### Added network response handling to network module:
- ErrorReason is added since our http endpoint doesn't have a representable error body in case of failure

- in case of successful response Success will be reflected
- in case of client side failure ClientError will be reflected
- in case of remote side failure ServerError will be reflected
- in case of network connection failure NetworkError will be reflected

NOTE: in network module build gradle there won't be any instrumented tests initially, maybe hilt injection tests later. But for now `testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"` Won't be necessary in `core/network/build.gradle.kts`