### PR TITLE
Encrypt db and passphrase

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -16,6 +16,7 @@ android {
         consumerProguardFiles("consumer-rules.pro")
 
         buildConfigField ("String", "DATABASE_NAME", "\"books-db\"")
+        buildConfigField("String", "DB_PASSPHRASE", "\"my-passphrase123\"")
     }
 
     buildTypes {
@@ -56,6 +57,13 @@ dependencies {
 
     // room - paging
     implementation(libs.androidx.room.paging)
+
+    // Security
+    implementation (libs.androidx.security.crypto)
+
+    // Sqlcipher
+    implementation (libs.sqlcipher.android)
+
 
     implementation(projects.core.common)
 }

--- a/core/database/src/androidTest/java/com/shahin/core/database/di/RoomModuleTest.kt
+++ b/core/database/src/androidTest/java/com/shahin/core/database/di/RoomModuleTest.kt
@@ -1,0 +1,138 @@
+package com.shahin.core.database.di
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.shahin.core.database.AppDatabase
+import com.shahin.core.database.BuildConfig
+import com.shahin.core.database.common.Constants.DB_PASSPHRASE_KEY
+import com.shahin.core.database.common.Constants.DB_PREFS
+import com.shahin.core.database.encryption.SupportFactory
+import com.shahin.core.database.extensions.hash
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltAndroidTest
+class RoomModuleTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    @Named(DB_PASSPHRASE_KEY)
+    lateinit var currentPassphrase: String
+
+    @Inject
+    lateinit var supportFactory: SupportFactory
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun testProvidingSupportFactory_firstTimeAppLaunch() {
+        val sharedPrefs = context.getSharedPreferences(DB_PREFS, Context.MODE_PRIVATE)
+        sharedPrefs.edit().clear().apply()
+
+        // since first time there is no shared key stored yet, no password is considered as changed
+        assertEquals(false, supportFactory.passphraseChanged)
+
+        // check if the current password [currentPassphrase] is equal to what that's been passed to room - should pass
+        assertEquals(
+            currentPassphrase,
+            supportFactory.currentPassphrase
+        )
+    }
+
+    @Test
+    fun testProvidingSupportFactory_passwordUnchanged() {
+        val sharedPrefs = context.getSharedPreferences(DB_PREFS, Context.MODE_PRIVATE)
+        sharedPrefs.edit().putString(DB_PASSPHRASE_KEY, currentPassphrase).apply()
+
+        // check implementation of checking phrases
+        val passwordChanged = sharedPrefs.getString(DB_PASSPHRASE_KEY, null)
+            ?.equals(currentPassphrase, ignoreCase = false)?.not() ?: false
+
+        assertEquals(false, passwordChanged)
+
+        // check if the current password is equal to what that's been passed to room - should pass
+        assertEquals(
+            currentPassphrase,
+            supportFactory.currentPassphrase
+        )
+
+        // check if the latest password is stored in shared preferences
+        assertEquals(
+            sharedPrefs.getString(DB_PASSPHRASE_KEY, null),
+            currentPassphrase
+        )
+    }
+
+    /**
+     * Simulating the scenario where the passphrase for the db is changed
+     */
+    @Test
+    fun testProvidingSupportFactory_passwordChanged() {
+        val sharedPrefs = context.getSharedPreferences(DB_PREFS, Context.MODE_PRIVATE)
+
+        // first we clear whatever shared prefs that are stored, we assign a new value later anyways
+        sharedPrefs.edit().clear().apply()
+
+        // we assume our old password is the following
+        val oldPassphrase = "my_old_passphrase".hash()
+
+
+        // first check if shared preference is empty, cause this is a test and we want to mock the mentioned scenario
+        assertNotEquals(sharedPrefs.getString(DB_PASSPHRASE_KEY, null), oldPassphrase)
+        assertNull(sharedPrefs.getString(DB_PASSPHRASE_KEY, null))
+
+        // so we forcefully put [oldPassphrase] as our old passphrase into our shared preferences
+        sharedPrefs.edit().putString(DB_PASSPHRASE_KEY, oldPassphrase).apply()
+
+        // check again if the shared preference is really set
+        assertNotNull(sharedPrefs.getString(DB_PASSPHRASE_KEY, null))
+        assertEquals(sharedPrefs.getString(DB_PASSPHRASE_KEY, null), oldPassphrase)
+
+        // check implementation of checking phrases
+        val passwordChanged = sharedPrefs.getString(DB_PASSPHRASE_KEY, null)
+            ?.equals(currentPassphrase, ignoreCase = false)?.not() ?: false
+
+        assertEquals(true, passwordChanged)
+
+        // and we should check if the old passphrase isn't the one we're sending to our Room via [provideSupportFactory]
+        assertNotEquals(
+            oldPassphrase,
+            supportFactory.currentPassphrase
+        )
+
+        // and finally we should check if our [currentPassphrase] is being sent to our Room instead
+        assertEquals(
+            currentPassphrase,
+            supportFactory.currentPassphrase
+        )
+    }
+
+    @Test
+    fun testProvidingAppDatabaseWithSupportFactory() {
+        val db = Room.databaseBuilder(context, AppDatabase::class.java, BuildConfig.DATABASE_NAME)
+            .openHelperFactory(supportFactory.supportFactory)
+            .build()
+
+        assertNotNull(supportFactory.passphraseChanged)
+        assertNotNull(supportFactory.currentPassphrase)
+        assertNotNull(db)
+    }
+}

--- a/core/database/src/main/java/com/shahin/core/database/AppDatabase.kt
+++ b/core/database/src/main/java/com/shahin/core/database/AppDatabase.kt
@@ -14,7 +14,8 @@ import com.shahin.core.database.books.sources.BooksDao
     entities = [
         BookEntity::class
     ],
-    version = 1
+    version = 1,
+    exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
 

--- a/core/database/src/main/java/com/shahin/core/database/common/Constants.kt
+++ b/core/database/src/main/java/com/shahin/core/database/common/Constants.kt
@@ -1,0 +1,7 @@
+package com.shahin.core.database.common
+
+object Constants {
+    const val SQL_CIPHER = "sqlcipher"
+    const val DB_PREFS = "dbPrefs"
+    const val DB_PASSPHRASE_KEY = "passphraseKey"
+}

--- a/core/database/src/main/java/com/shahin/core/database/di/BuildModule.kt
+++ b/core/database/src/main/java/com/shahin/core/database/di/BuildModule.kt
@@ -1,0 +1,20 @@
+package com.shahin.core.database.di
+
+import com.shahin.core.database.BuildConfig
+import com.shahin.core.database.common.Constants.DB_PASSPHRASE_KEY
+import com.shahin.core.database.extensions.hash
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BuildModule {
+
+    @Provides
+    @Named(DB_PASSPHRASE_KEY)
+    fun getCurrentDbPassPhrase(): String = BuildConfig.DB_PASSPHRASE.hash()
+
+}

--- a/core/database/src/main/java/com/shahin/core/database/di/RoomModule.kt
+++ b/core/database/src/main/java/com/shahin/core/database/di/RoomModule.kt
@@ -1,15 +1,25 @@
 package com.shahin.core.database.di
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.room.Room
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 import com.shahin.core.database.AppDatabase
 import com.shahin.core.database.BuildConfig.DATABASE_NAME
 import com.shahin.core.database.books.sources.BooksDao
+import com.shahin.core.database.common.Constants.DB_PASSPHRASE_KEY
+import com.shahin.core.database.common.Constants.DB_PREFS
+import com.shahin.core.database.common.Constants.SQL_CIPHER
+import com.shahin.core.database.encryption.SupportFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
+import java.nio.charset.StandardCharsets
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -18,13 +28,64 @@ class RoomModule {
 
     @Singleton
     @Provides
-    fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
-        return Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME).build()
+    fun provideAppDatabase(
+        @ApplicationContext context: Context,
+        supportFactory: SupportFactory
+    ): AppDatabase {
+        val room = Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
+            .openHelperFactory(supportFactory.supportFactory)
+            .build()
+
+        if (supportFactory.passphraseChanged == true) {
+            room.query("PRAGMA rekey = '${supportFactory.currentPassphrase}';", emptyArray())
+        }
+
+        return room
     }
 
     @Provides
     fun provideBooksDao(appDatabase: AppDatabase): BooksDao {
         return appDatabase.booksDao()
     }
+
+    @Provides
+    @Singleton
+    fun provideSupportFactory(
+        @ApplicationContext context: Context,
+        @Named(DB_PASSPHRASE_KEY) currentPassphrase: String,
+    ): SupportFactory {
+        return try {
+            System.loadLibrary(SQL_CIPHER)
+
+            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+            val sharedPrefs: SharedPreferences = EncryptedSharedPreferences.create(
+                DB_PREFS,
+                masterKeyAlias,
+                context,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+
+            val oldPassphrase = sharedPrefs.getString(DB_PASSPHRASE_KEY, null)
+
+            val passwordChanged = oldPassphrase?.equals(currentPassphrase, ignoreCase = false)?.not() ?: false
+
+            sharedPrefs.edit().putString(DB_PASSPHRASE_KEY, currentPassphrase).apply()
+
+            SupportFactory(
+                supportFactory = SupportOpenHelperFactory(
+                    oldPassphrase?.toByteArray(StandardCharsets.UTF_8)
+                        ?: currentPassphrase.toByteArray(StandardCharsets.UTF_8)
+                ),
+                passphraseChanged = passwordChanged,
+                currentPassphrase = currentPassphrase
+            )
+        } catch (e: UnsatisfiedLinkError) {
+            e.printStackTrace()
+            SupportFactory()
+        }
+    }
+
 
 }

--- a/core/database/src/main/java/com/shahin/core/database/encryption/SupportFactory.kt
+++ b/core/database/src/main/java/com/shahin/core/database/encryption/SupportFactory.kt
@@ -1,0 +1,9 @@
+package com.shahin.core.database.encryption
+
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
+
+data class SupportFactory(
+    val supportFactory: SupportOpenHelperFactory? = null,
+    val passphraseChanged: Boolean? = null,
+    val currentPassphrase: String? = null
+)

--- a/core/database/src/main/java/com/shahin/core/database/extensions/StringExtensions.kt
+++ b/core/database/src/main/java/com/shahin/core/database/extensions/StringExtensions.kt
@@ -1,0 +1,11 @@
+package com.shahin.core.database.extensions
+
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+fun String.hash(): String {
+    val messageDigest = MessageDigest.getInstance("SHA-256")
+    val hashBytes = messageDigest.digest(toByteArray(StandardCharsets.UTF_8))
+    return Base64.encodeToString(hashBytes, Base64.NO_WRAP)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ mockitoKotlin = "5.3.1"
 runner = "1.5.2"
 kotlinxCoroutinesTest = "1.6.1"
 room = "2.6.1"
+securityCrypto = "1.0.0"
+sqlcipherAndroid = "4.6.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -66,6 +68,11 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "room" }
 
+# security crypto
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
+
+# sqlcipher
+sqlcipher-android = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipherAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- `:core:database` will be responsible for the entire encryption
- passphrase value, although not so safe, is assigned to a filed named `DB_PASSPHRASE` in gradle
- since we store previous passphrases, since they change in future updates, Shared preferences is used combined with security-crypto
- `security-crypto` will be responsible for encrypting our shared preference values and hashing
- sqlcipher-android will be responsible for encrypting our room database
- passphrases will be hashed using `security-crypto` SHA-256 algorithm via `String.hash()` extension combined with `Base64` encoding.