### PR TITLE
Add date formatting

### DIFF
--- a/core/common/src/androidTest/java/com/shahin/core/common/extensions/StringExtensionsKtTest.kt
+++ b/core/common/src/androidTest/java/com/shahin/core/common/extensions/StringExtensionsKtTest.kt
@@ -1,5 +1,7 @@
 package com.shahin.core.common.extensions
 
+import com.shahin.core.common.commons.Constants.BOOK_MINE_DATE_PATTERN
+import com.shahin.core.common.commons.Constants.MOCKEY_DATE_PATTERN
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
@@ -15,5 +17,41 @@ class StringExtensionsTest {
 
         val realHashedString = "bNrLEmmfOM+rvV6f4ZQSktn6JQrYWnpdnX6VtUttSWA="
         assertEquals(hashedString, realHashedString)
+    }
+
+    @Test
+    fun testDatePatterns() {
+        val date = "10/18/1851"
+        val expectedDateValue = "Fri, Jan 10, '51"
+
+        val formattedDate = date.formatReleaseDate(
+            inputPattern = MOCKEY_DATE_PATTERN,
+            outputPattern = BOOK_MINE_DATE_PATTERN
+        )
+        assertEquals(formattedDate, expectedDateValue)
+    }
+
+    @Test
+    fun testInvalidDatePatterns() {
+        val date = "800 BC"
+        val expectedDateValue = "800 BC"
+
+        val formattedDate = date.formatReleaseDate(
+            inputPattern = MOCKEY_DATE_PATTERN,
+            outputPattern = BOOK_MINE_DATE_PATTERN
+        )
+        assertEquals(formattedDate, expectedDateValue)
+    }
+
+    @Test
+    fun testAnotherInvalidDatePatterns() {
+        val date = "1320"
+        val expectedDateValue = "1320"
+
+        val formattedDate = date.formatReleaseDate(
+            inputPattern = MOCKEY_DATE_PATTERN,
+            outputPattern = BOOK_MINE_DATE_PATTERN
+        )
+        assertEquals(formattedDate, expectedDateValue)
     }
 }

--- a/core/common/src/main/java/com/shahin/core/common/commons/Constants.kt
+++ b/core/common/src/main/java/com/shahin/core/common/commons/Constants.kt
@@ -1,0 +1,6 @@
+package com.shahin.core.common.commons
+
+object Constants {
+    const val MOCKEY_DATE_PATTERN = "dd/mm/yyyy"
+    const val BOOK_MINE_DATE_PATTERN = "EEE, MMM d, ''yy"
+}

--- a/core/common/src/main/java/com/shahin/core/common/extensions/StringExtensions.kt
+++ b/core/common/src/main/java/com/shahin/core/common/extensions/StringExtensions.kt
@@ -3,9 +3,41 @@ package com.shahin.core.common.extensions
 import android.util.Base64
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 
 fun String.hash(): String {
     val messageDigest = MessageDigest.getInstance("SHA-256")
     val hashBytes = messageDigest.digest(toByteArray(StandardCharsets.UTF_8))
     return Base64.encodeToString(hashBytes, Base64.NO_WRAP)
+}
+
+fun String.formatReleaseDate(inputPattern: String, outputPattern: String): String {
+    if (isBlank()) return this
+    return getFormattedDate(
+        dateString = this,
+        inputPattern = inputPattern,
+        outputPattern = outputPattern
+    )
+}
+
+private fun getFormattedDate(
+    dateString: String,
+    inputPattern: String,
+    outputPattern: String,
+): String {
+    val inputFormatter = SimpleDateFormat(inputPattern, Locale.US)
+    inputFormatter.timeZone = TimeZone.getTimeZone("UTC")
+    try {
+        val parsedDate = inputFormatter.parse(dateString)
+        if (parsedDate != null) {
+            val outputFormatter = SimpleDateFormat(outputPattern, Locale.US)
+            outputFormatter.timeZone = TimeZone.getTimeZone("UTC")
+            return outputFormatter.format(parsedDate)
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+    return dateString
 }

--- a/feature/book_details/build.gradle.kts
+++ b/feature/book_details/build.gradle.kts
@@ -68,4 +68,5 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation(projects.core.database)
+    implementation(projects.core.common)
 }

--- a/feature/book_details/src/main/java/com/shahin/feature/book_details/presentation/BookDetailsScreen.kt
+++ b/feature/book_details/src/main/java/com/shahin/feature/book_details/presentation/BookDetailsScreen.kt
@@ -57,6 +57,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.shahin.core.common.commons.Constants.BOOK_MINE_DATE_PATTERN
+import com.shahin.core.common.commons.Constants.MOCKEY_DATE_PATTERN
+import com.shahin.core.common.extensions.formatReleaseDate
 import com.shahin.feature.book_details.R
 import com.shahin.feature.book_details.data.model.BookDetails
 import com.shahin.feature.book_details.presentation.ui.theme.BackButtonSize
@@ -255,7 +258,10 @@ private fun TopHeaderTitle(
                     modifier = Modifier
                         .align(Alignment.End)
                         .testTag("header-release-date"),
-                    text = bookDetails?.releaseDate.orEmpty(),
+                    text = bookDetails?.releaseDate.orEmpty().formatReleaseDate(
+                        inputPattern = MOCKEY_DATE_PATTERN,
+                        outputPattern = BOOK_MINE_DATE_PATTERN
+                    ),
                     style = MaterialTheme.typography.titleSmall
                 )
             }
@@ -293,7 +299,10 @@ private fun DetailsScreenContent(
                 modifier = Modifier
                     .align(Alignment.End)
                     .testTag("details-release-date"),
-                text = bookDetails?.releaseDate.orEmpty(),
+                text = bookDetails?.releaseDate.orEmpty().formatReleaseDate(
+                    inputPattern = MOCKEY_DATE_PATTERN,
+                    outputPattern = BOOK_MINE_DATE_PATTERN
+                ),
                 style = MaterialTheme.typography.titleSmall
             )
             Text(


### PR DESCRIPTION
[Add date formatting](https://github.com/shahin68/bookmine/commit/c04fe2e5ae464b320db3286b9679f92981b64bc6) 

- Dates that are not as commonly recognized formatting such as `800 BC` won't be formatted. They will appear exactly how they're received.

So for "800 BC" we will see "800 BC"

- All formatting will be handled by a String extension placed within `:core:common` module to be used whenever they're needed
- `formatReleaseDate` extension will accept any input and output pattern that are valid and parsable
- Other way of formatting dates are also suitable options such as `DateFormat.getDateInstance()` or using Calendar instance to extract specific characters

- tests are provided in `StringExtensionsKtTest.kt`